### PR TITLE
update go toolchain to 1.23.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/minio/mc
 
 go 1.23.0
 
-toolchain go1.23.10
+toolchain go1.23.12
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
## Description

Bump go toolchain version to 1.23.12 to resolve several CVEs:

- CVE-2025-4674
- CVE-2025-47907
- CVE-2025-4673